### PR TITLE
rook-ceph: install kubernetes python module in ceph image

### DIFF
--- a/images/ceph/Dockerfile
+++ b/images/ceph/Dockerfile
@@ -18,12 +18,14 @@ RUN yum --assumeyes install \
     dbus \
     yum-plugin-copr \
     net-tools \
-    nmap-ncat && \
+    nmap-ncat \
+    python2-pip && \
     yum --assumeyes copr enable jlayton/ceph && \
     yum --assumeyes copr enable jlayton/nfs-ganesha && \
     yum --assumeyes update libcephfs2 librados2 libntirpc nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha && \
     yum --assumeyes install nfs-ganesha-rados-grace && \
-    yum clean all && rm -rf /tmp/* /var/tmp/*
+    yum clean all && rm -rf /tmp/* /var/tmp/* && \
+    pip install kubernetes
 
 ARG ARCH
 ARG TINI_VERSION


### PR DESCRIPTION
ceph-mgr has an extension for rook, but it requires the kubernetes
python module. Let's install it as a matter of course when generating
rook images.

Signed-off-by: Jeff Layton <jlayton@redhat.com>