### PR TITLE
Add --force to ceph mgr config settings

### DIFF
--- a/Documentation/advanced-configuration.md
+++ b/Documentation/advanced-configuration.md
@@ -480,7 +480,7 @@ between each restart to ensure the cluster goes back to "active/clean" state.
 - MDS: the pods are stateless and can be restarted as needed
 
 After the pod restart, your new settings should be in effect. Note that if you create
-the ConfigMap in the `rook` namespace before the cluster is even created
+the ConfigMap in the `rook-ceph` namespace before the cluster is even created
 the daemons will pick up the settings at first launch.
 
 The only validation of the settings done by Rook is whether the settings can be merged

--- a/Documentation/cassandra-cluster-crd.md
+++ b/Documentation/cassandra-cluster-crd.md
@@ -50,10 +50,12 @@ spec:
                 - matchExpressions:
                   - key: failure-domain.beta.kubernetes.io/region
                     operator: In
-                    values: us-east-1
+                    values: 
+                      - us-east-1
                   - key: failure-domain.beta.kubernetes.io/zone
                     operator: In
-                    value: us-east-1a
+                    values: 
+                      - us-east-1a
 ```
 
 ## Settings Explanation
@@ -79,7 +81,6 @@ Rack Settings:
 * `resources`: Defines the CPU and RAM resources for the Cassandra Pods.
 * `placement`: Defines the placement of Cassandra Pods. Has the following subfields:
     * [`nodeAffinity`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
-    * [`nodeAntiAffinity`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
     * [`podAffinity`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
     * [`podAntiAffinity`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
     * [`tolerations`](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)

--- a/Documentation/cassandra.md
+++ b/Documentation/cassandra.md
@@ -30,87 +30,88 @@ This will install the operator in namespace rook-cassandra-system. You can check
   kubectl -n rook-cassandra-system get pod
  ```
  
- ## Create and Initialize a Cassandra/Scylla Cluster
- 
- Now that the operator is running, we can create an instance of a Cassandra/Scylla cluster by creating an instance of the `clusters.cassandra.rook.io` resource.
- Some of that resource's values are configurable, so feel free to browse `cluster.yaml` and tweak the settings to your liking.
- Full details for all the configuration options can be found in the [Cassandra Cluster CRD documentation](cassandra-cluster-crd.md).
- 
- When you are ready to create a Cassandra cluster, simply run:
- 
- ```console
- kubectl create -f cluster.yaml
- ```
- 
- We can verify that a Kubernetes object has been created that represents our new Cassandra cluster with the command below.
- This is important because it shows that Rook has successfully extended Kubernetes to make Cassandra clusters a first class citizen in the Kubernetes cloud-native environment.
- 
- ```console
- kubectl -n rook-cassandra get clusters.cassandra.rook.io
- ```
- 
- To check if all the desired members are running, you should see the same number of entries from the following command as the number of members that was specified in `cluster.yaml`:
- 
- ```console
- kubectl -n rook-cassandra get pod -l app=rook-cassandra
- ```
- 
- You can also track the state of a Cassandra cluster from its status. To check the current status of a Cluster, run:
- 
- ```console
- kubectl -n rook-cassandra describe clusters.cassandra.rook.io rook-cassandra
- ```
- 
- ## Accessing the Database
+## Create and Initialize a Cassandra/Scylla Cluster
+
+Now that the operator is running, we can create an instance of a Cassandra/Scylla cluster by creating an instance of the `clusters.cassandra.rook.io` resource.
+Some of that resource's values are configurable, so feel free to browse `cluster.yaml` and tweak the settings to your liking.
+Full details for all the configuration options can be found in the [Cassandra Cluster CRD documentation](cassandra-cluster-crd.md).
+
+When you are ready to create a Cassandra cluster, simply run:
+
+```console
+kubectl create -f cluster.yaml
+```
+
+We can verify that a Kubernetes object has been created that represents our new Cassandra cluster with the command below.
+This is important because it shows that Rook has successfully extended Kubernetes to make Cassandra clusters a first class citizen in the Kubernetes cloud-native environment.
+
+```console
+kubectl -n rook-cassandra get clusters.cassandra.rook.io
+```
+
+To check if all the desired members are running, you should see the same number of entries from the following command as the number of members that was specified in `cluster.yaml`:
+
+```console
+kubectl -n rook-cassandra get pod -l app=rook-cassandra
+```
+
+You can also track the state of a Cassandra cluster from its status. To check the current status of a Cluster, run:
+
+```console
+kubectl -n rook-cassandra describe clusters.cassandra.rook.io rook-cassandra
+```
+
+## Accessing the Database
 
 * From kubectl:
 
 To get a cqlsh shell in your new Cluster:
- ```console
- kubectl exec -n rook-cassandra -it rook-cassandra-east-1-east-1a-0 -- cqlsh
- > DESCRIBE KEYSPACES;
- ```
- 
- 
+```console
+kubectl exec -n rook-cassandra -it rook-cassandra-east-1-east-1a-0 -- cqlsh
+> DESCRIBE KEYSPACES;
+```
+
+
 * From inside a Pod:
 
- When you create a new Cluster, Rook automatically creates a Service for the clients to use in order to access the Cluster. The service's name follows the convention `<cluster-name>-client`. You can see this Service in you cluster by running:
- ```console
- kubectl -n rook-cassandra describe service rook-cassandra-client
- ```
- Pods running inside the Kubernetes cluster can use this Service to connect to Cassandra.
- Here's an example using the [Python Driver](https://github.com/datastax/python-driver):
- ```python
- from cassandra.cluster import Cluster
- 
- cluster = Cluster(['rook-cassandra-client.rook-cassandra.svc.cluster.local'])
- session = cluster.connect()
+When you create a new Cluster, Rook automatically creates a Service for the clients to use in order to access the Cluster. The service's name follows the convention `<cluster-name>-client`. You can see this Service in you cluster by running:
+```console
+kubectl -n rook-cassandra describe service rook-cassandra-client
+```
+Pods running inside the Kubernetes cluster can use this Service to connect to Cassandra.
+Here's an example using the [Python Driver](https://github.com/datastax/python-driver):
+```python
+from cassandra.cluster import Cluster
+
+cluster = Cluster(['rook-cassandra-client.rook-cassandra.svc.cluster.local'])
+session = cluster.connect()
 ```
 
 ## Scale Up
 
 The operator supports scale up of a rack as well as addition of new racks. To make the changes, you can use:
- ```console
- kubectl edit clusters.cassandra.rook.io rook-cassandra
- ```
- * To scale up a rack, change the `Spec.Members` field of the rack to the desired value.
- * To add a new rack, append the `racks` list with a new rack. Remember to choose a different rack name for the new rack.
- * After editing and saving the yaml, check your cluster's Status and Events for information on what's happening:  
- ```console
- kubectl -n rook-cassandra describe clusters.cassandra.rook.io rook-cassandra 
- ```
+```console
+kubectl edit clusters.cassandra.rook.io rook-cassandra
+```
+* To scale up a rack, change the `Spec.Members` field of the rack to the desired value.
+* To add a new rack, append the `racks` list with a new rack. Remember to choose a different rack name for the new rack.
+* After editing and saving the yaml, check your cluster's Status and Events for information on what's happening:  
+```console
+kubectl -n rook-cassandra describe clusters.cassandra.rook.io rook-cassandra 
+```
+
  
 ## Scale Down
 
 The operator supports scale down of a rack. To make the changes, you can use:
- ```console
- kubectl edit clusters.cassandra.rook.io rook-cassandra
- ```
- * To scale down a rack, change the `Spec.Members` field of the rack to the desired value.
- * After editing and saving the yaml, check your cluster's Status and Events for information on what's happening:
- ```console
- kubectl -n rook-cassandra describe clusters.cassandra.rook.io rook-cassandra
- ```
+```console
+kubectl edit clusters.cassandra.rook.io rook-cassandra
+```
+* To scale down a rack, change the `Spec.Members` field of the rack to the desired value.
+* After editing and saving the yaml, check your cluster's Status and Events for information on what's happening:
+```console
+kubectl -n rook-cassandra describe clusters.cassandra.rook.io rook-cassandra
+```
   
 ## Clean Up
  

--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -24,6 +24,9 @@ spec:
     # see the "Cluster Settings" section below for more details on which image of ceph to run
     image: ceph/ceph:v13.2.2-20181023
   dataDirHostPath: /var/lib/rook
+  mon:
+    count: 3
+    allowMultiplePerNode: true
   storage:
     useAllNodes: true
     useAllDevices: true
@@ -179,8 +182,9 @@ spec:
   cephVersion:
     image: ceph/ceph:v13.2.2-20181023
   dataDirHostPath: /var/lib/rook
-  network:
-    hostNetwork: false
+  mon:
+    count: 3
+    allowMultiplePerNode: true
   dashboard:
     enabled: true
   # cluster level storage configuration and selection
@@ -210,8 +214,9 @@ spec:
   cephVersion:
     image: ceph/ceph:v13.2.2-20181023
   dataDirHostPath: /var/lib/rook
-  network:
-    hostNetwork: false
+  mon:
+    count: 3
+    allowMultiplePerNode: true
   dashboard:
     enabled: true
   # cluster level storage configuration and selection
@@ -252,8 +257,9 @@ spec:
   cephVersion:
     image: ceph/ceph:v13.2.2-20181023
   dataDirHostPath: /var/lib/rook
-  network:
-    hostNetwork: false
+  mon:
+    count: 3
+    allowMultiplePerNode: true
   dashboard:
     enabled: true
   # cluster level storage configuration and selection
@@ -288,8 +294,10 @@ spec:
   cephVersion:
     image: ceph/ceph:v13.2.2-20181023
   dataDirHostPath: /var/lib/rook
-  network:
-    hostNetwork: false
+  mon:
+    count: 3
+    allowMultiplePerNode: true
+  # enable the ceph dashboard for viewing cluster status
   dashboard:
     enabled: true
   placement:
@@ -332,6 +340,12 @@ spec:
   cephVersion:
     image: ceph/ceph:v13.2.2-20181023
   dataDirHostPath: /var/lib/rook
+  mon:
+    count: 3
+    allowMultiplePerNode: true
+  # enable the ceph dashboard for viewing cluster status
+  dashboard:
+    enabled: true
   # cluster level resource requests/limits configuration
   resources:
   storage:

--- a/Documentation/ceph-monitoring.md
+++ b/Documentation/ceph-monitoring.md
@@ -81,7 +81,7 @@ You can find Prometheus Consoles here: https://github.com/ceph/cephmetrics/tree/
 A guide to how you can write your own Prometheus consoles can be found on the official Prometheus site here: https://prometheus.io/docs/visualization/consoles/.
 
 ## Grafana Dashboards
-The dashboards have been created by [@galexrt](https://github.com/galexrt). For feedback on the dashboards please reach out to him on the [Rook.io Slack](https://rook-slackin.herokuapp.com/).
+The dashboards have been created by [@galexrt](https://github.com/galexrt). For feedback on the dashboards please reach out to him on the [Rook.io Slack](https://slack.rook.io).
 
 > **NOTE** The dashboards are only compatible with Grafana 5.0.3 or higher.
 

--- a/Documentation/ceph-pool-crd.md
+++ b/Documentation/ceph-pool-crd.md
@@ -72,6 +72,8 @@ When creating an erasure-coded pool, it is highly recommended to create the pool
 with the default of `host`. For example, if you have replication of size `3` and the failure domain is `host`, all three copies of the data will be
 placed on osds that are found on unique hosts. In that case you would be guaranteed to tolerate the failure of two hosts. If the failure domain were `osd`,
 you would be able to tolerate the loss of two devices. Similarly for erasure coding, the data and coding chunks would be spread across the requested failure domain.
+<br>**NOTE:** Neither Rook nor Ceph will prevent the user from creating a cluster where data (or chunks) cannot be replicated safely;
+it is Ceph's design to delay checking for OSDs until a write request is made, and the write will hang if there are not sufficient OSDs to satisfy the request.
 - `crushRoot`: The root in the crush map to be used by the pool. If left empty or unspecified, the default root will be used. Creating a crush hierarchy for the OSDs currently requires the Rook toolbox to run the Ceph tools described [here](http://docs.ceph.com/docs/master/rados/operations/crush-map/#modifying-the-crush-map).
 
 ### Erasure Coding

--- a/Documentation/ceph-quickstart.md
+++ b/Documentation/ceph-quickstart.md
@@ -222,11 +222,11 @@ spec:
     # For the latest ceph images, see https://hub.docker.com/r/ceph/ceph/tags
     image: ceph/ceph:v13.2.2-20181023
   dataDirHostPath: /var/lib/rook
-  dashboard:
-    enabled: true
   mon:
     count: 3
     allowMultiplePerNode: true
+  dashboard:
+    enabled: true
   storage:
     useAllNodes: true
     useAllDevices: false

--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -97,6 +97,13 @@ kind: CephCluster
   namespace: rook-ceph
 spec:
   dataDirHostPath: /var/lib/rook
+  # set the amount of mons to be started
+  mon:
+    count: 3
+    allowMultiplePerNode: true
+  # enable the ceph dashboard for viewing cluster status
+  dashboard:
+    enabled: true
   storage:
     useAllNodes: true
     useAllDevices: true

--- a/Documentation/common-issues.md
+++ b/Documentation/common-issues.md
@@ -8,7 +8,7 @@ indent: true
 
 Many of these problem cases are hard to summarize down to a short phrase that adequately describes the problem. Each problem will start with a bulleted list of symptoms. Keep in mind that all symptoms may not apply depending upon the configuration of the Rook. If the majority of the symptoms are seen there is a fair chance you are experiencing that problem.
 
-If after trying the suggestions found on this page and the problem is not resolved, the Rook team is very happy to help you troubleshoot the issues in their Slack channel. Once you have [registered for the Rook Slack](https://rook-slackin.herokuapp.com/), proceed to the General channel to ask for assistance.
+If after trying the suggestions found on this page and the problem is not resolved, the Rook team is very happy to help you troubleshoot the issues in their Slack channel. Once you have [registered for the Rook Slack](https://slack.rook.io), proceed to the General channel to ask for assistance.
 
 ## Table of Contents
 - [Troubleshooting Techniques](#troubleshooting-techniques)
@@ -227,7 +227,7 @@ This will happen in kernels with versions older than 4.7, where the option `mds_
 
 In this case, if there is only one filesystem in the Rook cluster, there should be no issues and the mount should succeed. If you have more than one filesystem, inconsistent results may arise and the filesystem mounted may not be the one you specified.
 
-If the issue is still not resolved from the steps above, please come chat with us on the **#general** channel of our [Rook Slack](https://rook-slackin.herokuapp.com/).
+If the issue is still not resolved from the steps above, please come chat with us on the **#general** channel of our [Rook Slack](https://slack.rook.io).
 We want to help you get your storage working and learn from those lessons to prevent users in the future from seeing the same issue.
 
 # Cluster failing to service requests

--- a/Documentation/quickstart-toc.md
+++ b/Documentation/quickstart-toc.md
@@ -6,7 +6,7 @@ weight: 2
 # Quickstart Guides
 
 Welcome to Rook! We hope you have a great experience installing the Rook storage platform to enable highly available, durable storage
-in your cluster. If you have any questions along the way, please don't hesitate to ask us in our [Slack channel](https://rook-io.slack.com). You can sign up for our Slack [here](https://rook-slackin.herokuapp.com/).
+in your cluster. If you have any questions along the way, please don't hesitate to ask us in our [Slack channel](https://rook-io.slack.com). You can sign up for our Slack [here](https://slack.rook.io).
 
 Rook provides growing number of storage providers to a Kubernetes cluster, each with its own operator to deploy and manage the cluster. Follow these guides to get started with each provider.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/rook/rook)](https://goreportcard.com/report/github.com/rook/rook)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1599/badge)](https://bestpractices.coreinfrastructure.org/projects/1599)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Frook%2Frook.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Frook%2Frook?ref=badge_shield)
-[![Slack](https://rook-slackin.herokuapp.com/badge.svg)](https://rook-slackin.herokuapp.com/badge.svg)
+[![Slack](https://slack.rook.io/badge.svg)](https://slack.rook.io/badge.svg)
 [![Twitter Follow](https://img.shields.io/twitter/follow/rook_io.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=rook_io&user_id=788180534543339520)
 
 ## What is Rook?

--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -20,11 +20,11 @@ func MgrDisableModule(context *clusterd.Context, clusterName, name string) error
 
 // MgrSetAllConfig applies a setting for all mgr daemons
 func MgrSetAllConfig(context *clusterd.Context, clusterName, cephVersionName, key, val string) (bool, error) {
-	return MgrSetConfig(context, clusterName, "", cephVersionName, key, val)
+	return MgrSetConfig(context, clusterName, "", cephVersionName, key, val, false)
 }
 
 // MgrSetConfig applies a setting for a single mgr daemon
-func MgrSetConfig(context *clusterd.Context, clusterName, mgrName, cephVersionName, key, val string) (bool, error) {
+func MgrSetConfig(context *clusterd.Context, clusterName, mgrName, cephVersionName, key, val string, force bool) (bool, error) {
 	var getArgs, setArgs []string
 	mgrID := fmt.Sprintf("mgr.%s", mgrName)
 	if cephVersionName == cephv1.Luminous || cephVersionName == "" {
@@ -40,6 +40,9 @@ func MgrSetConfig(context *clusterd.Context, clusterName, mgrName, cephVersionNa
 			setArgs = append(setArgs, "config", "rm", mgrID, key)
 		} else {
 			setArgs = append(setArgs, "config", "set", mgrID, key, val)
+		}
+		if force {
+			setArgs = append(setArgs, "--force")
 		}
 	}
 

--- a/pkg/daemon/ceph/mgr/init.go
+++ b/pkg/daemon/ceph/mgr/init.go
@@ -86,7 +86,7 @@ func setServerAddr(context *clusterd.Context, config *Config) error {
 	modules := []string{"prometheus", "dashboard"}
 	for _, module := range modules {
 		settingPath := fmt.Sprintf("mgr/%s/server_addr", module)
-		if _, err := client.MgrSetConfig(context, clusterName, config.Name, config.CephVersionName, settingPath, config.ModuleServerAddr); err != nil {
+		if _, err := client.MgrSetConfig(context, clusterName, config.Name, config.CephVersionName, settingPath, config.ModuleServerAddr, true); err != nil {
 			return fmt.Errorf("setting %s server_addr failed. %+v", module, err)
 		}
 	}


### PR DESCRIPTION
This patch fixes an issue I was seeing when starting the mgr with recently build ceph-container images. It fixes the problem for me, but I'm now wondering whether we need to exclude this flag on ceph versions =< mimic.